### PR TITLE
Update renovate.json; disable automerges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>maybeanerd/renovate-config", ":automergeDisabled"]
+  "extends": ["github>maybeanerd/renovate-config"],
+  "minor": {
+    "automerge": true
+  },
+  "patch": {
+    "automerge": true
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>maybeanerd/renovate-config"],
   "minor": {
-    "automerge": true
+    "automerge": false
   },
   "patch": {
-    "automerge": true
+    "automerge": false
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>maybeanerd/renovate-config"],
-  "automerge": false
+  "extends": ["github>maybeanerd/renovate-config", ":automergeDisabled"]
 }


### PR DESCRIPTION
Due to us using :automergeMinor in the default config, we need to disable specific automerges it activated, and cannot simply set automerge:false globally. It will be overridden by the more specific ones